### PR TITLE
Using string iterator instead of creating new strings

### DIFF
--- a/flint/Polyfill.cpp
+++ b/flint/Polyfill.cpp
@@ -138,13 +138,27 @@ namespace flint {
 	*
 	* @param str
 	*		The string to search
-	* @param suffix
+	* @param prefix
 	*		The prefix to search for
 	* @return
 	*		Returns true if str ends with an instance of prefix
 	*/
 	bool startsWith(const string &str, const string &prefix) {
 		return mismatch(begin(prefix), end(prefix), begin(str)).first == end(prefix);
+	};
+
+	/**
+	* Tests if a given string starts with a prefix
+	*
+	* @param str_iter
+	*		The string position to start search
+	* @param prefix
+	*		The prefix to search for
+	* @return
+	*		Returns true if str ends with an instance of prefix
+	*/
+	bool startsWith(string::const_iterator str_iter, const string &prefix) {
+		return mismatch(begin(prefix), end(prefix), str_iter).first == end(prefix);
 	};
 
 	/**

--- a/flint/Polyfill.hpp
+++ b/flint/Polyfill.hpp
@@ -41,5 +41,7 @@ namespace flint {
 
 	bool startsWith(const string &str, const string &prefix);
 
+	bool startsWith(string::const_iterator str_iter, const string &prefix);
+
 	string escapeString(const string &input);
 };


### PR DESCRIPTION
So instead of chomping the string we're processing, instead use an iterator into the data (since it's always a substring of input).

This avoids a bunch of string re-allocations.
The best part is that the performance is now much better.

Run time from the original test run (a few commits ago): Flint++ - 0m0.987s
Present run time after the iterator and file changes: real    0m0.281s
It's actually faster now than Facebook's C++ version :)

By the way, this is the profile of the project tested on:
Lint Summary: 642 files
Errors: 91 Warnings: 397 Advice: 268 

@L2Program I had to comment out some assert calls because I no longer had access to `.size()` from the iterator.  I'll leave it up to you to decide what we should do with them.
