### PR TITLE
Fix possible dereference on last file character

### DIFF
--- a/flint/Tokenizer.cpp
+++ b/flint/Tokenizer.cpp
@@ -255,7 +255,7 @@ namespace flint {
 		size_t tokenLen;
 		string whitespace = "";
 
-		while (1) {
+		while (pc != input.end()) {
 			const char c = *pc;
 
 			// Special case for parseing #include <...>
@@ -392,7 +392,7 @@ namespace flint {
 			case '\0':
 				//assert(pc.size() == 0);
 				// Push last token, the EOF
-				output.push_back(Token(TK_EOF, string(&*pc), line, whitespace));
+				output.push_back(Token(TK_EOF, "", line, whitespace));
 				return;
 				// *** Verboten characters (do allow '@' and '$' as extensions)
 			case '`':


### PR DESCRIPTION
Not the cause of the problem I figure, but safer anyway.

Can you run on MSVC and see if the problem is there with this anyway?
I'll look into the other location as well.
