### PR TITLE
Use unordered_map when key order is not important

### DIFF
--- a/flint/Checks.cpp
+++ b/flint/Checks.cpp
@@ -1,7 +1,7 @@
 #include "Checks.hpp"
 
 #include <algorithm>
-#include <map>
+#include <unordered_map>
 #include <set>
 #include <cassert>
 #include <stdexcept>
@@ -610,7 +610,7 @@ namespace flint {
 	void checkBlacklistedIdentifiers(ErrorFile &errors, const string &path, const vector<Token> &tokens) {
 
 
-		static const map<string, pair<Lint,string>> blacklist = {
+		static const unordered_map<string, pair<Lint,string>> blacklist = {
 			{ "strtok",
 				{ Lint::ERROR, "'strtok' is not thread safe. Consider 'strtok_r'." }
 			},
@@ -625,7 +625,7 @@ namespace flint {
 			if (isTok(tokens[pos], TK_IDENTIFIER)) {
 				for (const auto &entry : blacklist) {
 					if (cmpTok(tokens[pos], entry.first)) {
-						auto desc = entry.second;
+						auto& desc = entry.second;
 						lint(errors, tokens[pos], desc.first, desc.second);
 						continue;
 					}

--- a/flint/Options.hpp
+++ b/flint/Options.hpp
@@ -2,7 +2,8 @@
 
 #include <iostream>
 #include <string>
-#include <map>
+#include <unordered_map>
+#include <vector>
 
 using namespace std;
 
@@ -75,7 +76,7 @@ namespace flint {
 		Arg argJSON			= { ArgType::BOOL, &Options.JSON };
 		Arg argLevel		= { ArgType::INT,  &Options.LEVEL };
 
-		static const map<string, Arg &> params = {
+		static const unordered_map<string, Arg &> params = {
 			{ "-h", argHelp },
 			{ "--help", argHelp },
 

--- a/flint/Tokenizer.cpp
+++ b/flint/Tokenizer.cpp
@@ -1,7 +1,7 @@
 #include "Tokenizer.hpp"
 
 #include <algorithm>
-#include <map>
+#include <unordered_map>
 #include <cassert>
 #include <stdexcept>
 
@@ -13,8 +13,8 @@ namespace flint {
 		
 		// Black magic code expansion from Token Definitions
 		// See header...
-		static map<string, TokenType> initializeKeywords() {
-			map<string, TokenType> result;
+		static unordered_map<string, TokenType> initializeKeywords() {
+			unordered_map<string, TokenType> result;
 		#define CPPLINT_ASSIGN(s, tk) result[string(s)] = tk;
 			CPPLINT_FORALL_KEYWORDS(CPPLINT_ASSIGN)
 		#undef CPPLINT_ASSIGN
@@ -32,7 +32,7 @@ namespace flint {
 		/**
 		* Map containing mappings of the kind "virtual" -> TK_VIRTUAL.
 		*/
-		static map<string, TokenType> keywords = initializeKeywords();
+		static unordered_map<string, TokenType> keywords = initializeKeywords();
 
 		/**
 		* Eats howMany characters out of pc, advances pc appropriately, and

--- a/flint/tests/expected.txt
+++ b/flint/tests/expected.txt
@@ -19,9 +19,10 @@
 [Error  ] Throw.cpp:12: Heap-allocated exception: throw new MyException(); This is usually a mistake in c++.
 [Error  ] ImplicitConversion.cpp:15: operator bool() is dangerous.
 [Error  ] Blacklist.cpp:21: 'strtok' is not thread safe. Consider 'strtok_r'.
-[Warning] Blacklist.cpp:8: 'volatile' is not thread-safe.
 [Advice ] Blacklist.cpp:23: Prefer `nullptr' to `NULL' in new C++ code.
+[Warning] Blacklist.cpp:8: 'volatile' is not thread-safe.
 
 Lint Summary: 8 files
 Errors: 15 Warnings: 7 Advice: 1 
 
+Estimated Lines of Code: 154


### PR DESCRIPTION
- Unordered_map is faster for lookup, O(1) vs O(logn).  We profiled them
  previously with GCC 4.8.1 to make sure, it holds even for small
  collections.

I saw also a lot of string copying in the Checks, I'm going to look to
cut those down as well.
