### PR TITLE
Use StringFragment to avoid creating new strings

### DIFF
--- a/flint/Polyfill.cpp
+++ b/flint/Polyfill.cpp
@@ -143,8 +143,9 @@ namespace flint {
 	* @return
 	*		Returns true if str ends with an instance of prefix
 	*/
-	bool startsWith(const string &str, const string &prefix) {
-		return mismatch(begin(prefix), end(prefix), begin(str)).first == end(prefix);
+	template <class T>
+	bool startsWith(const T &str, const T &prefix) {
+		return equal(begin(prefix), end(prefix), begin(str));
 	};
 
 	/**

--- a/flint/Tokenizer.hpp
+++ b/flint/Tokenizer.hpp
@@ -222,20 +222,49 @@ namespace flint {
 	string toString(TokenType t);
 
 	/**
+	 * Defines a substring of an existing string.  Lifetime is limited to the lifetime of the enclosing string
+	 * In other words, a StringFragment will take no ownership of any memory.
+	 *
+	 * Note: Remember to respect the range of most C++ iterators, which operate on [begin, end) (so end expected to be out of range)
+	 */
+	struct StringFragment {
+		typedef string::const_iterator iterator;
+		typedef char value_type;
+		typedef const char& const_reference;
+		typedef size_t size_type;
+		
+		iterator begin_;
+		iterator end_;
+
+		value_type back() const { return *(end_ - 1); }
+		iterator begin() const { return begin_; }
+		iterator end() const { return end_; }
+		const_reference operator[](size_type pos) const { return *(begin_ + pos); }
+		const_reference operator[](size_type pos) { return *(begin_ + pos); } 
+		size_type size() const { return end_ - begin_; }
+	};
+
+	using std::to_string;
+	string to_string(const StringFragment &fragment);
+	bool operator==(const StringFragment &a, const StringFragment &b);
+	
+	/**
 	* Defines one token together with file and line information. The
 	* precedingComment_ is set if there was one comment before the token.
 	*/
 	struct Token {
 		TokenType type_;
-		string value_;
+		StringFragment value_;
 		string precedingWhitespace_;
 		size_t line_;
 
-		Token(TokenType type, string value, size_t line, string whitespace)
+		Token(TokenType type, StringFragment value, size_t line, string whitespace)
 			: type_(type), value_(move(value)), precedingWhitespace_(move(whitespace)), line_(line) {};
 
 		string toString() const {
-			return string("Line:" + to_string(line_) + ":" + value_);
+			string result = string("Line:" + to_string(line_) + ':');
+			result.append(value_.begin(), value_.end());
+			return result;
 		};
 	};
 


### PR DESCRIPTION
- Use StringFragment as the result of the munch functions.
- append to string directly from the StringFragment as opposed to converting to string.

This worked out really nicely in terms of cutting down the amount of computation.  Chopped over 20% of the instructions according to valgrind (running against folly+gtest+double_conversion).

Can now process all that in 2.259 s, versus the 3.7 for Facebook's C++ Flint.

Had to replace a macro with an inline function to take advantage of templates.
