### PR TITLE
Hash StringFragment

### DIFF
--- a/flint/Tokenizer.hpp
+++ b/flint/Tokenizer.hpp
@@ -288,3 +288,10 @@ namespace flint {
 	size_t tokenize(string&&, const string &, vector<Token> &) = delete;
 	size_t tokenize(const string&, string &&, vector<Token> &) = delete;
 };
+
+namespace std {
+	template <>
+	struct hash<flint::StringFragment>;
+};
+
+

--- a/flint/tests/expected.txt
+++ b/flint/tests/expected.txt
@@ -23,6 +23,6 @@
 [Warning] Blacklist.cpp:8: 'volatile' is not thread-safe.
 
 Lint Summary: 8 files
-Errors: 15 Warnings: 7 Advice: 1 
+Errors: 15 Warnings: 7 Advice: 1
 
 Estimated Lines of Code: 154


### PR DESCRIPTION
Implement `std::hash` for StringFragment.
Allows us to use it as a key in associative containers instead of
converting it to a string first.
