### PR TITLE
Implement checkNamespaceScopedStatics

### DIFF
--- a/flint/Main.cpp
+++ b/flint/Main.cpp
@@ -94,6 +94,7 @@ void checkEntry(ErrorReport &errors, const string &path, size_t &loc, uint depth
 			checkBlacklistedSequences(errorFile, path, tokens);
 			checkDefinedNames(errorFile, path, tokens);
 			checkDeprecatedIncludes(errorFile, path, tokens);
+			checkNamespaceScopedStatics(errorFile, path, tokens);
 
 			if (!Options.CMODE) {
 				checkImplicitCast(errorFile, path, tokens, structures);

--- a/flint/tests/Namespace.hpp
+++ b/flint/tests/Namespace.hpp
@@ -1,0 +1,35 @@
+#ifndef NAMESPACE_HPP
+#define NAMESPACE_HPP
+
+namespace Named {
+  static int x = 5;
+  static const int y = 9;
+
+  namespace Good {
+    int x = 6;
+    const int y = 15;
+  }
+};
+
+namespace {
+  static int a = 11;
+  static const int b = 15;
+
+  namespace InnerNamed {
+    static int s = 8;
+  }
+};
+
+namespace {
+  int c = 13;
+  const int d = 7;
+};
+
+int foo()
+{
+  static int p = 7;
+
+  return Named::x + Named::y + a + b + Named::Good::x + Named::Good::y + c + d + p + InnerNamed::s;
+};
+
+#endif

--- a/flint/tests/expected.txt
+++ b/flint/tests/expected.txt
@@ -10,6 +10,11 @@
 [Error  ] Includes.cpp:4: An -inl file (Wrong-inl.h) was included even though this is not its associated header.
 [Warning] Includes.cpp:6: Including deprecated header 'common/base/Base.h'
 [Error  ] Ifdef.cpp:15: Unmatched #if/#endif.
+[Warning] Namespace.hpp:5: Don't use static variables at global or namespace scopes.
+[Warning] Namespace.hpp:6: Don't use static variables at global or namespace scopes.
+[Warning] Namespace.hpp:15: Don't use static variables at global or namespace scopes.
+[Warning] Namespace.hpp:16: Don't use static variables at global or namespace scopes.
+[Warning] Namespace.hpp:19: Don't use static variables at global or namespace scopes.
 [Error  ] Memset.cpp:11: Did you mean memset(ptr, 0, 4) ?
 [Error  ] Memset.cpp:13: Did you mean memset(ptr, 1, sizeof(int)) ?
 [Error  ] Define.hpp:12: Include guard doesn't cover the entire file.
@@ -22,7 +27,7 @@
 [Advice ] Blacklist.cpp:23: Prefer `nullptr' to `NULL' in new C++ code.
 [Warning] Blacklist.cpp:8: 'volatile' is not thread-safe.
 
-Lint Summary: 8 files
-Errors: 15 Warnings: 7 Advice: 1
+Lint Summary: 9 files
+Errors: 15 Warnings: 12 Advice: 1
 
-Estimated Lines of Code: 154
+Estimated Lines of Code: 190


### PR DESCRIPTION
Avoid static variables in namespace and global scope in headers.

I'm not sure about the warning message, so feel free to change it.
