### PR TITLE
Update test expected out and warning message

### DIFF
--- a/flint/Checks.cpp
+++ b/flint/Checks.cpp
@@ -691,7 +691,7 @@ inline bool cmpStr(const string &a, const string &b) { return a == b; }
 			}
 
 			if (isTok(tokens[pos], TK_STATIC)) {
-				lintWarning(errors, tokens[pos], "Don't use static at global or namespace scopes.");
+				lintWarning(errors, tokens[pos], "Don't use static at global or namespace scopes in headers.");
 			}
 		}
 	};

--- a/flint/tests/expected.txt
+++ b/flint/tests/expected.txt
@@ -10,11 +10,12 @@
 [Error  ] Includes.cpp:4: An -inl file (Wrong-inl.h) was included even though this is not its associated header.
 [Warning] Includes.cpp:6: Including deprecated header 'common/base/Base.h'
 [Error  ] Ifdef.cpp:15: Unmatched #if/#endif.
-[Warning] Namespace.hpp:5: Don't use static variables at global or namespace scopes.
-[Warning] Namespace.hpp:6: Don't use static variables at global or namespace scopes.
-[Warning] Namespace.hpp:15: Don't use static variables at global or namespace scopes.
-[Warning] Namespace.hpp:16: Don't use static variables at global or namespace scopes.
-[Warning] Namespace.hpp:19: Don't use static variables at global or namespace scopes.
+[Warning] Namespace.hpp:5: Don't use static at global or namespace scopes in headers.
+[Warning] Namespace.hpp:6: Don't use static at global or namespace scopes in headers.
+[Warning] Namespace.hpp:15: Don't use static at global or namespace scopes in headers.
+[Warning] Namespace.hpp:16: Don't use static at global or namespace scopes in headers.
+[Warning] Namespace.hpp:19: Don't use static at global or namespace scopes in headers.
+[Warning] Namespace.hpp:21: Don't use static at global or namespace scopes in headers.
 [Error  ] Memset.cpp:11: Did you mean memset(ptr, 0, 4) ?
 [Error  ] Memset.cpp:13: Did you mean memset(ptr, 1, sizeof(int)) ?
 [Error  ] Define.hpp:12: Include guard doesn't cover the entire file.
@@ -28,6 +29,6 @@
 [Warning] Blacklist.cpp:8: 'volatile' is not thread-safe.
 
 Lint Summary: 9 files
-Errors: 15 Warnings: 12 Advice: 1
+Errors: 15 Warnings: 13 Advice: 1
 
-Estimated Lines of Code: 190
+Estimated Lines of Code: 194


### PR DESCRIPTION
Specified that the warning was for doing it in headers.

Updated the expected output in the tests.
With this rule, we're no longer passing linting, as Options.hpp violates the rule.
