### PR TITLE
Update Options source files to pass linting

### DIFF
--- a/flint/Options.cpp
+++ b/flint/Options.cpp
@@ -1,0 +1,127 @@
+#include "Options.hpp"
+
+using namespace std;
+
+namespace flint {
+	OptionsInfo Options;
+
+        /**
+	* Prints the usage information for the program, then exits.
+	*/
+        void printHelp() {
+		printf("Usage: flint++ [options:] [files:]\n\n"
+			   "\t-r, --recursive		: Search subfolders for files.\n"
+			   "\t-c, --cmode		: Only perform C based lint checks.\n"
+			   "\t-j, --json		: Output report in JSON format.\n"
+			   "\t-l, --level [value:]	: Set the lint level.\n"
+			   "			      0 : Errors only\n"
+			   "			      1 : Errors & Warnings\n"
+			   "			      2 : All feedback\n\n"
+			   "\t-h, --help		: Print usage.\n\n");
+                #ifdef _DEBUG 
+		// Stop visual studio from closing the window...
+		system("PAUSE");
+                #endif
+		exit(1);
+	};
+
+        /**
+	* Given an argument count and list, parses the arguments
+	* and sets the global options as desired
+	*
+	* @param argc
+	*		The number of arguments
+	* @param argv
+	*		The list of cmd line arguments
+	* @param paths
+	*		A vector of strings to be filled with lint paths
+	*/
+        void parseArgs(int argc, char* argv[], vector<string> &paths) {
+		// Set default values
+		Options.RECURSIVE	= false;
+		Options.CMODE		= false;
+		Options.JSON		= false;
+		Options.LEVEL		= Lint::ADVICE;
+		bool HELP			= false;
+
+		enum ArgType {
+			BOOL, INT
+		};
+		struct Arg {
+			ArgType type;
+			const void *ptr;
+		};
+
+		// Map values to their cmd line flags
+		Arg argHelp			= { ArgType::BOOL, &HELP };
+		Arg argRecursive	= { ArgType::BOOL, &Options.RECURSIVE };
+		Arg argCMode		= { ArgType::BOOL, &Options.CMODE };
+		Arg argJSON			= { ArgType::BOOL, &Options.JSON };
+		Arg argLevel		= { ArgType::INT,  &Options.LEVEL };
+
+		static const unordered_map<string, Arg &> params = {
+			{ "-h", argHelp },
+			{ "--help", argHelp },
+
+			{ "-r", argRecursive },
+			{ "--recursive", argRecursive },
+
+			{ "-c", argCMode },
+			{ "--cmode", argCMode },
+
+			{ "-j", argJSON },
+			{ "--json", argJSON },
+
+			{ "-l", argLevel },
+			{ "--level", argLevel }
+		};
+
+		// Loop over the given argument list
+		for (int i = 1; i < argc; ++i) {
+			
+			// If the current argument is in the map
+			// then set its value to true
+			auto it = params.find(string(argv[i]));
+			if (it != params.end()) {
+				
+				if (it->second.type == ArgType::BOOL) {
+					bool *arg = (bool*)it->second.ptr;
+					*arg = true;
+				}
+				else if (it->second.type == ArgType::INT) {
+					int *arg = (int*) it->second.ptr;
+
+					++i;
+					if (i >= argc) {
+						printf("Missing (int) value for parameter: %s\n\n", 
+							it->first.c_str());
+						printHelp();
+					}
+
+					int val = atoi(argv[i]);
+					*arg = val;
+					continue;
+				}
+			}
+			else {
+				// Push another path onto the lint list
+				string p = argv[i];
+				if (p.back() == '/' || p.back() == '\\') {
+					p.erase(p.end()-1, p.end());
+				}
+				paths.push_back(move(p));
+			}
+		}
+
+		// Make sure level was given a correct value
+		Options.LEVEL = ((Options.LEVEL > Lint::ADVICE) ? 
+			Lint::ADVICE : 
+			((Options.LEVEL < Lint::ERROR) ? 
+				Lint::ERROR : 
+				Options.LEVEL));
+
+		if (HELP || argc == 1 || paths.size() == 0) {
+			printHelp();
+		}
+	};
+};

--- a/flint/Options.hpp
+++ b/flint/Options.hpp
@@ -5,140 +5,21 @@
 #include <unordered_map>
 #include <vector>
 
-using namespace std;
-
 namespace flint {
 	
 	enum Lint {
 		ERROR, WARNING, ADVICE
 	};
 
-	static struct {
+	struct OptionsInfo {
 		bool RECURSIVE;
 		bool CMODE;
 		bool JSON;
 
 		int  LEVEL;
-	} Options;
-
-	/**
-	* Prints the usage information for the program, then exits.
-	*/
-	static void printHelp() {
-		printf("Usage: flint++ [options:] [files:]\n\n"
-			   "\t-r, --recursive		: Search subfolders for files.\n"
-			   "\t-c, --cmode		: Only perform C based lint checks.\n"
-			   "\t-j, --json		: Output report in JSON format.\n"
-			   "\t-l, --level [value:]	: Set the lint level.\n"
-			   "			      0 : Errors only\n"
-			   "			      1 : Errors & Warnings\n"
-			   "			      2 : All feedback\n\n"
-			   "\t-h, --help		: Print usage.\n\n");
-#ifdef _DEBUG 
-		// Stop visual studio from closing the window...
-		system("PAUSE");
-#endif
-		exit(1);
 	};
-
-	/**
-	* Given an argument count and list, parses the arguments
-	* and sets the global options as desired
-	*
-	* @param argc
-	*		The number of arguments
-	* @param argv
-	*		The list of cmd line arguments
-	* @param paths
-	*		A vector of strings to be filled with lint paths
-	*/
-	static void parseArgs(int argc, char* argv[], vector<string> &paths) {
-		
-		// Set default values
-		Options.RECURSIVE	= false;
-		Options.CMODE		= false;
-		Options.JSON		= false;
-		Options.LEVEL		= Lint::ADVICE;
-		bool HELP			= false;
-
-		enum ArgType {
-			BOOL, INT
-		};
-		struct Arg {
-			ArgType type;
-			const void *ptr;
-		};
-
-		// Map values to their cmd line flags
-		Arg argHelp			= { ArgType::BOOL, &HELP };
-		Arg argRecursive	= { ArgType::BOOL, &Options.RECURSIVE };
-		Arg argCMode		= { ArgType::BOOL, &Options.CMODE };
-		Arg argJSON			= { ArgType::BOOL, &Options.JSON };
-		Arg argLevel		= { ArgType::INT,  &Options.LEVEL };
-
-		static const unordered_map<string, Arg &> params = {
-			{ "-h", argHelp },
-			{ "--help", argHelp },
-
-			{ "-r", argRecursive },
-			{ "--recursive", argRecursive },
-
-			{ "-c", argCMode },
-			{ "--cmode", argCMode },
-
-			{ "-j", argJSON },
-			{ "--json", argJSON },
-
-			{ "-l", argLevel },
-			{ "--level", argLevel }
-		};
-
-		// Loop over the given argument list
-		for (int i = 1; i < argc; ++i) {
-			
-			// If the current argument is in the map
-			// then set its value to true
-			auto it = params.find(string(argv[i]));
-			if (it != params.end()) {
-				
-				if (it->second.type == ArgType::BOOL) {
-					bool *arg = (bool*)it->second.ptr;
-					*arg = true;
-				}
-				else if (it->second.type == ArgType::INT) {
-					int *arg = (int*) it->second.ptr;
-
-					++i;
-					if (i >= argc) {
-						printf("Missing (int) value for parameter: %s\n\n", 
-							it->first.c_str());
-						printHelp();
-					}
-
-					int val = atoi(argv[i]);
-					*arg = val;
-					continue;
-				}
-			}
-			else {
-				// Push another path onto the lint list
-				string p = argv[i];
-				if (p.back() == '/' || p.back() == '\\') {
-					p.erase(p.end()-1, p.end());
-				}
-				paths.push_back(move(p));
-			}
-		}
-
-		// Make sure level was given a correct value
-		Options.LEVEL = ((Options.LEVEL > Lint::ADVICE) ? 
-			Lint::ADVICE : 
-			((Options.LEVEL < Lint::ERROR) ? 
-				Lint::ERROR : 
-				Options.LEVEL));
-
-		if (HELP || argc == 1 || paths.size() == 0) {
-			printHelp();
-		}
-	};
+	extern OptionsInfo Options;	
+	
+        void printHelp(); 
+        void parseArgs(int argc, char* argv[], std::vector<std::string> &paths);
 };

--- a/flint/tests/expected.txt
+++ b/flint/tests/expected.txt
@@ -1,6 +1,3 @@
-[Error  ] Blacklist.cpp:21: 'strtok' is not thread safe. Consider 'strtok_r'.
-[Advice ] Blacklist.cpp:23: Prefer `nullptr' to `NULL' in new C++ code.
-[Warning] Blacklist.cpp:8: 'volatile' is not thread-safe.
 [Error  ] Constructor.cpp:24: Single - argument constructor 'Foo(int i)' may inadvertently be used as a type conversion constructor.
 [Error  ] Constructor.cpp:29: Move constructors should not take a const argument: Foo(const Foo&& other)
 [Error  ] Constructor.cpp:30: Copy constructors should take a const argument: Foo(Foo &other)
@@ -9,30 +6,37 @@
 [Warning] Constructor.cpp:12: Throw specifications on functions are deprecated.
 [Warning] Constructor.cpp:18: Throw specifications on functions are deprecated.
 [Warning] Constructor.cpp:5: Throw specifications on functions are deprecated.
-[Error  ] Define.hpp:12: Include guard doesn't cover the entire file.
-[Warning] Define.hpp:5: Symbol __BAD_DEFINE invalid.
-[Error  ] Ifdef.cpp:15: Unmatched #if/#endif.
-[Error  ] ImplicitConversion.cpp:15: operator bool() is dangerous.
 [Error  ] Includes.cpp:15: The associated header file of .cpp files should be included before any other includes.
 [Error  ] Includes.cpp:4: An -inl file (Wrong-inl.h) was included even though this is not its associated header.
 [Warning] Includes.cpp:6: Including deprecated header 'common/base/Base.h'
-[Error  ] Memset.cpp:11: Did you mean memset(ptr, 0, 4) ?
-[Error  ] Memset.cpp:13: Did you mean memset(ptr, 1, sizeof(int)) ?
+[Error  ] Ifdef.cpp:15: Unmatched #if/#endif.
 [Warning] Namespace.hpp:5: Don't use static at global or namespace scopes in headers.
 [Warning] Namespace.hpp:6: Don't use static at global or namespace scopes in headers.
 [Warning] Namespace.hpp:15: Don't use static at global or namespace scopes in headers.
 [Warning] Namespace.hpp:16: Don't use static at global or namespace scopes in headers.
 [Warning] Namespace.hpp:19: Don't use static at global or namespace scopes in headers.
 [Warning] Namespace.hpp:21: Don't use static at global or namespace scopes in headers.
+[Error  ] Memset.cpp:11: Did you mean memset(ptr, 0, 4) ?
+[Error  ] Memset.cpp:13: Did you mean memset(ptr, 1, sizeof(int)) ?
+[Error  ] Define.hpp:12: Include guard doesn't cover the entire file.
+[Warning] Define.hpp:5: Symbol __BAD_DEFINE invalid.
+[Error  ] Throw.cpp:8: Heap-allocated exception: throw new MyException(); This is usually a mistake in c++.
+[Error  ] Throw.cpp:10: Heap-allocated exception: throw new (MyException)(); This is usually a mistake in c++.
+[Error  ] Throw.cpp:12: Heap-allocated exception: throw new MyException(); This is usually a mistake in c++.
 [Error  ] Pointers.cpp:22: unique_ptr<T[]> should be used with an array type.
 [Error  ] Pointers.cpp:23: unique_ptr<T> should be unique_ptr<T[]> when used with an array.
 [Error  ] Pointers.cpp:26: unique_ptr<T[]> should be used with an array type.
 [Error  ] Pointers.cpp:27: unique_ptr<T> should be unique_ptr<T[]> when used with an array.
-[Error  ] Throw.cpp:8: Heap-allocated exception: throw new MyException(); This is usually a mistake in c++.
-[Error  ] Throw.cpp:10: Heap-allocated exception: throw new (MyException)(); This is usually a mistake in c++.
-[Error  ] Throw.cpp:12: Heap-allocated exception: throw new MyException(); This is usually a mistake in c++.
+[Warning] Pointers.cpp:30: Consider using 'allocate_shared' which performs better with fewer allocations.
+[Warning] Pointers.cpp:31: Consider using 'make_shared' which performs better with fewer allocations.
+[Warning] Pointers.cpp:32: Consider using 'make_shared' which performs better with fewer allocations.
+[Warning] Pointers.cpp:33: Consider using 'allocate_shared' which performs better with fewer allocations.
+[Error  ] ImplicitConversion.cpp:15: operator bool() is dangerous.
+[Error  ] Blacklist.cpp:21: 'strtok' is not thread safe. Consider 'strtok_r'.
+[Advice ] Blacklist.cpp:23: Prefer `nullptr' to `NULL' in new C++ code.
+[Warning] Blacklist.cpp:8: 'volatile' is not thread-safe.
 
 Lint Summary: 10 files
-Errors: 19 Warnings: 13 Advice: 1
+Errors: 19 Warnings: 17 Advice: 1
 
-Estimated Lines of Code: 224
+Estimated Lines of Code: 231


### PR DESCRIPTION
Options.hpp was violating the namespaceStatic rules.
- Made functions and data structure non-static
- Moved functions into cpp file to avoid multiple definition of non-static functions
- Extern declaration of Options (as it's accessed from multiple files).

The change to update the expected.txt in the other PR is also included, as I did that to pass testing here.
