### PR TITLE
Replace Whitespace string with StringFragment

### DIFF
--- a/flint/Checks.cpp
+++ b/flint/Checks.cpp
@@ -1343,7 +1343,7 @@ using TokenIter = vector<Token>::const_iterator;
 					}
 
 					// Check for preceding /* implicit */
-					if (tok.precedingWhitespace_.find(lintOverride) != string::npos) {
+					if (contains(tok.precedingWhitespace_, lintOverride.cbegin(), lintOverride.cend())) {
 						pos = skipFunctionDeclaration(tokens, pos);
 						continue;
 					}
@@ -1708,7 +1708,7 @@ using TokenIter = vector<Token>::const_iterator;
 
 				// Only want to process operators which do not have the overide
 				if (!isTok(tok, TK_OPERATOR)
-					|| tok.precedingWhitespace_.find(lintOverride) != string::npos) {
+					|| contains(tok.precedingWhitespace_, lintOverride.cbegin(), lintOverride.cend())) {
 					continue;
 				}
 

--- a/flint/FileCategories.cpp
+++ b/flint/FileCategories.cpp
@@ -40,7 +40,7 @@ namespace flint {
 	 */
 	 template <class Container>
 	 bool containsSuffix(const string &str, Container suffixes) {
-		return find_if(begin(suffixes), end(suffixes), bind(hasSuffix, str, placeholders::_1)) != end(suffixes);
+		return find_if(begin(suffixes), end(suffixes), bind(hasSuffix, cref(str), placeholders::_1)) != end(suffixes);
 	 }
 
 	/**

--- a/flint/Tokenizer.hpp
+++ b/flint/Tokenizer.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <algorithm>
+#include <cassert>
 #include <cstring>
 #include <string>
 #include <vector>
@@ -239,12 +241,24 @@ namespace flint {
 		iterator begin_;
 		iterator end_;
 
+		inline StringFragment(iterator begin, iterator end) noexcept : begin_(begin), end_(end) {}
+
 		value_type back() const { return *(end_ - 1); }
 		iterator begin() const { return begin_; }
 		iterator end() const { return end_; }
 		const_reference operator[](size_type pos) const { return *(begin_ + pos); }
 		const_reference operator[](size_type pos) { return *(begin_ + pos); } 
 		size_type size() const { return end_ - begin_; }
+		void append(iterator startPos, iterator endPos) {
+			assert(begin_ == end_ || end_ == startPos);
+
+			if (begin_ == end_) {
+				begin_ = startPos;
+				end_ = endPos;
+			}
+			end_ = endPos;
+		}
+		bool empty() const { return begin_ == end_; }
 	};
 
 	using std::to_string;
@@ -256,6 +270,10 @@ namespace flint {
 		return equal(a.begin(), a.end(), b.begin());
 	}
 
+	inline bool contains(const StringFragment &fragment, StringFragment::iterator stringBegin, StringFragment::iterator stringEnd) {
+		return search(fragment.begin(), fragment.end(), stringBegin, stringEnd) != fragment.end();
+	}
+
 	/**
 	* Defines one token together with file and line information. The
 	* precedingComment_ is set if there was one comment before the token.
@@ -263,10 +281,10 @@ namespace flint {
 	struct Token {
 		TokenType type_;
 		StringFragment value_;
-		string precedingWhitespace_;
+		StringFragment precedingWhitespace_;
 		size_t line_;
 
-		Token(TokenType type, StringFragment value, size_t line, string whitespace)
+		Token(TokenType type, StringFragment value, size_t line, StringFragment whitespace)
 			: type_(type), value_(move(value)), precedingWhitespace_(move(whitespace)), line_(line) {};
 
 		string toString() const {

--- a/flint/tests/expected.txt
+++ b/flint/tests/expected.txt
@@ -41,11 +41,14 @@
 [Warning] Pointers.cpp:35: Consider using 'make_shared' which performs better with fewer allocations.
 [Warning] Pointers.cpp:36: Consider using 'make_shared' which performs better with fewer allocations.
 [Warning] Pointers.cpp:37: Consider using 'allocate_shared' which performs better with fewer allocations.
+[Warning] Throw.cpp:14: Symbol 'int' invalid in catch clause. You may only catch user-defined types.
+[Error  ] Throw.cpp:15: Symbol 'i' of type ' Foo i' caught by value. Use catch by (preferably const) reference throughout.
+[Error  ] Throw.cpp:21: Symbol 'Bar' of type ' Bar' caught by value. Use catch by (preferably const) reference throughout.
 [Error  ] Throw.cpp:8: Heap-allocated exception: throw new MyException(); This is usually a mistake in c++.
 [Error  ] Throw.cpp:10: Heap-allocated exception: throw new (MyException)(); This is usually a mistake in c++.
 [Error  ] Throw.cpp:12: Heap-allocated exception: throw new MyException(); This is usually a mistake in c++.
 
 Lint Summary: 12 files
-Errors: 21 Warnings: 24 Advice: 1
+Errors: 23 Warnings: 25 Advice: 1
 
-Estimated Lines of Code: 271
+Estimated Lines of Code: 280


### PR DESCRIPTION
Token currently has a constructed string indicating the preceding
whitespace.  Since this is contiguous and found in the input stream,
we can just use a StringFragment.

This delivered a very nice performance increase, as we avoid allocating
a ton of strings.

The run against folly+gtest+double_conversion is now down to 1 second,
even with all the new checks that we added.  According to valgrind, the number of "instructions" has been cut by about 46%.
