### PR TITLE
Check using namespace

### DIFF
--- a/flint/Checks.cpp
+++ b/flint/Checks.cpp
@@ -200,7 +200,7 @@ using TokenIter = vector<Token>::const_iterator;
 		* @return
 		*		Returns true is the token as pos is a built in type
 		*/
-		bool atBuiltinType(const vector<Token> &tokens, size_t pos) {
+		inline bool atBuiltinType(const vector<Token> &tokens, size_t pos) {
 
 			static const array<TokenType, 11> builtIns = {{
 				TK_DOUBLE,
@@ -733,6 +733,10 @@ using TokenIter = vector<Token>::const_iterator;
 			{TK_NAMESPACE, TK_LCURL}
 		};
 
+		static const array<TokenType, 2> usingNamespace = {
+			{TK_USING, TK_NAMESPACE}
+		};
+
 		for (size_t pos = 0, size = tokens.size(); pos < size; ++pos) {
 			if (atSequence(tokens, pos, regularNamespace)) {
 				pos += 2;
@@ -752,6 +756,11 @@ using TokenIter = vector<Token>::const_iterator;
 
 			if (isTok(tokens[pos], TK_STATIC)) {
 				lintWarning(errors, tokens[pos], "Don't use static at global or namespace scopes in headers.");
+			}
+
+			// Checking for 'using namespace' violations here as well
+			if (atSequence(tokens, pos, usingNamespace)) {
+				lintWarning(errors, tokens[pos], "Avoid the use of using namespace directives at global/namespace scope in headers");
 			}
 		}
 	};

--- a/flint/Checks.hpp
+++ b/flint/Checks.hpp
@@ -55,6 +55,5 @@ namespace flint {
 	X(UniquePtrUsage);
 	
 	// To be implemented...
-	X(UsingDirectives);
 	X(UsingNamespaceDirectives);	
 };

--- a/flint/tests/Namespace.hpp
+++ b/flint/tests/Namespace.hpp
@@ -1,6 +1,10 @@
 #ifndef NAMESPACE_HPP
 #define NAMESPACE_HPP
 
+#include <iostream>
+
+using namespace std;
+
 namespace Named {
   static int x = 5;
   static const int y = 9;
@@ -18,9 +22,10 @@ namespace {
   namespace InnerNamed {
     static int s = 8;
 
-	static bool testFunction() {
-		return false;
-	};
+    static bool testFunction() {
+      using namespace std; // This one is safe
+      return false;
+    };
   }
 };
 

--- a/flint/tests/expected.txt
+++ b/flint/tests/expected.txt
@@ -25,12 +25,13 @@
 [Warning] Includes.cpp:6: Including deprecated header 'common/base/Base.h'
 [Error  ] Memset.cpp:11: Did you mean memset(ptr, 0, 4) ?
 [Error  ] Memset.cpp:13: Did you mean memset(ptr, 1, sizeof(int)) ?
-[Warning] Namespace.hpp:5: Don't use static at global or namespace scopes in headers.
-[Warning] Namespace.hpp:6: Don't use static at global or namespace scopes in headers.
-[Warning] Namespace.hpp:15: Don't use static at global or namespace scopes in headers.
-[Warning] Namespace.hpp:16: Don't use static at global or namespace scopes in headers.
+[Warning] Namespace.hpp:6: Avoid the use of using namespace directives at global/namespace scope in headers
+[Warning] Namespace.hpp:9: Don't use static at global or namespace scopes in headers.
+[Warning] Namespace.hpp:10: Don't use static at global or namespace scopes in headers.
 [Warning] Namespace.hpp:19: Don't use static at global or namespace scopes in headers.
-[Warning] Namespace.hpp:21: Don't use static at global or namespace scopes in headers.
+[Warning] Namespace.hpp:20: Don't use static at global or namespace scopes in headers.
+[Warning] Namespace.hpp:23: Don't use static at global or namespace scopes in headers.
+[Warning] Namespace.hpp:25: Don't use static at global or namespace scopes in headers.
 [Error  ] Pointers.cpp:39: Mutex holder variable declared without a name, causing the lock to be released immediately.
 [Error  ] Pointers.cpp:40: Mutex holder variable declared without a name, causing the lock to be released immediately.
 [Error  ] Pointers.cpp:27: unique_ptr<T[]> should be used with an array type.
@@ -49,6 +50,6 @@
 [Error  ] Throw.cpp:12: Heap-allocated exception: throw new MyException(); This is usually a mistake in c++.
 
 Lint Summary: 12 files
-Errors: 23 Warnings: 25 Advice: 1
+Errors: 23 Warnings: 26 Advice: 1
 
-Estimated Lines of Code: 280
+Estimated Lines of Code: 285


### PR DESCRIPTION
It's pretty much the exact same logic as for static at global/namespace
scope.  Instead of 'static', we just need to check for 'using
namespace', so I included this check into the NamespaceScopedStatics
check.

Note that with this change the codebase no longer lints perfectly, since
we have 'using namespace std;' declarations in our headers.
