### PR TITLE
fixed Clang warning

### DIFF
--- a/flint/Polyfill.cpp
+++ b/flint/Polyfill.cpp
@@ -95,8 +95,8 @@ namespace flint {
 		//
 		DIR *pDIR;
 		struct dirent *entry;
-		if (pDIR = opendir(path.c_str())) {
-			while (entry = readdir(pDIR)) {
+		if ((pDIR = opendir(path.c_str()))) {
+			while ((entry = readdir(pDIR))) {
 				const string fsObj = entry->d_name;
 				if (FS_ISNOT_LINK(fsObj) && FS_ISNOT_GIT(fsObj)) {
 


### PR DESCRIPTION
Warning was:

```
Polyfill.cpp:98:12: warning: using the result of an assignment as a condition without parentheses [-Wparentheses]
                if (pDIR = opendir(path.c_str())) {
                    ~~~~~^~~~~~~~~~~~~~~~~~~~~~~
Polyfill.cpp:98:12: note: place parentheses around the assignment to silence this warning
                if (pDIR = opendir(path.c_str())) {
                         ^
                    (                           )
Polyfill.cpp:98:12: note: use '==' to turn this assignment into an equality comparison
                if (pDIR = opendir(path.c_str())) {
                         ^
                         ==
Polyfill.cpp:99:17: warning: using the result of an assignment as a condition without parentheses [-Wparentheses]
                        while (entry = readdir(pDIR)) {
                               ~~~~~~^~~~~~~~~~~~~~~
Polyfill.cpp:99:17: note: place parentheses around the assignment to silence this warning
                        while (entry = readdir(pDIR)) {
                                     ^
                               (                    )
Polyfill.cpp:99:17: note: use '==' to turn this assignment into an equality comparison
                        while (entry = readdir(pDIR)) {
                                     ^
                                     ==
```