### PR TITLE
fix assert failure when there's whitespace after backslash

### DIFF
--- a/flint/Tokenizer.cpp
+++ b/flint/Tokenizer.cpp
@@ -385,8 +385,9 @@ namespace flint {
 				// *** Backslash
 			case '\\':
 				// Consume trailing whitespace after a valid backslash
-				while (pc[1] == ' ' || pc[1] == '\t') {
-					++pc;
+				{
+					const auto &spaces = munchSpaces(pc);
+					whitespace.append(spaces.begin(), spaces.end());
 				}
 				// Take the case into account where a comment comes after a macro backslash
 				ENFORCE(pc[1] == '\n' || pc[1] == '\r' || (pc[1] == '/' && (pc[2] == '/' || pc[2] == '*')), "Misplaced backslash in " + file + ":" + to_string(line));


### PR DESCRIPTION
void append(iterator startPos, iterator endPos) {
assert(begin_ == end_ || end_ == startPos);

if (begin_ == end_) {
begin_ = startPos;
end_ = endPos;
}
end_ = endPos;
}


We must maintain startpos to meet end_