### PR TITLE
Fix issue #60: Whitespace between # and error or line causes bogus er…

### DIFF
--- a/flint/Tokenizer.cpp
+++ b/flint/Tokenizer.cpp
@@ -492,13 +492,13 @@ namespace flint {
 				// Skip ws
 				auto pc1 = pc + 1;
 				tokenLen = 1 + munchSpaces(pc1).size();
-				// define, include, pragma, or line
+				// The entire #line line is the token value
 				if (startsWith(pc1, "line")) {
-					t = TK_HASHLINE; tokenLen += distance(pc, find(pc1, input.end(), '\n'));
+					t = TK_HASHLINE; tokenLen += distance(pc1, find(pc1, input.end(), '\n'));
 				}
 				else if (startsWith(pc1, "error")) {
 					// The entire #error line is the token value
-					t = TK_ERROR; tokenLen += distance(pc, find(pc1, input.end(), '\n'));
+					t = TK_ERROR; tokenLen += distance(pc1, find(pc1, input.end(), '\n'));
 					ENFORCE(tokenLen > 0, "Unterminated #error message");
 				}
 				else if (startsWith(pc1, "include")) {

--- a/flint/tests/Error.hpp
+++ b/flint/tests/Error.hpp
@@ -1,0 +1,6 @@
+#ifndef ERROR_HPP
+#define ERROR_HPP
+#if abcdefg
+#  		     error Gadzooks.
+#endif
+#endif // ERROR_HPP

--- a/flint/tests/Line.hpp
+++ b/flint/tests/Line.hpp
@@ -1,0 +1,6 @@
+#ifndef LINE_HPP
+#define LINE_HPP
+#if abcdefg
+#  	     line 12345678
+#endif
+#endif // LINE_HPP

--- a/flint/tests/expected.txt
+++ b/flint/tests/expected.txt
@@ -52,7 +52,7 @@
 [Error  ] Throw.cpp:10: Heap-allocated exception: throw new (MyException)(); This is usually a mistake in c++.
 [Error  ] Throw.cpp:12: Heap-allocated exception: throw new MyException(); This is usually a mistake in c++.
 
-Lint Summary: 12 files
+Lint Summary: 14 files
 Errors: 23 Warnings: 29 Advice: 1
 
-Estimated Lines of Code: 292
+Estimated Lines of Code: 306


### PR DESCRIPTION
Fix for the two examples in the bug, plus test cases, plus an update to the test output.