### PR TITLE
Return non-zero exit when there are warnings or errors

### DIFF
--- a/flint/Main.cpp
+++ b/flint/Main.cpp
@@ -155,6 +155,11 @@ int main(int argc, char *argv[]) {
 	// Stop visual studio from closing the window...
 	system("PAUSE");
 #endif
+
+	if (errors.getWarnings() || errors.getErrors()) {
+		return 1;
+	}
+
 	return 0;
 };
 


### PR DESCRIPTION
Helps integrate with GitLab CI (and other CI) where a non-zero exit for a CI step counts as failure.